### PR TITLE
Fix flag types in about_flags.cc

### DIFF
--- a/chrome/browser/about_flags.cc
+++ b/chrome/browser/about_flags.cc
@@ -11319,10 +11319,10 @@ const FeatureEntry kFeatureEntries[] = {
 #endif
 	{"ungoogled-supermium",
 	 flag_descriptions::kUngoogledSupermiumName, flag_descriptions::kUngoogledSupermiumDescription, 
-	 kOsAll, SINGLE_VALUE_TYPE("disable-windows10-custom-titlebar")},
+	 kOsAll, SINGLE_VALUE_TYPE("ungoogled-supermium")},
 	{"disable-download-upload",
 	 flag_descriptions::kDisableDownloadUploadName, flag_descriptions::kDisableDownloadUploadDescription, 
-	 kOsAll, SINGLE_VALUE_TYPE("disable-windows10-custom-titlebar")},
+	 kOsAll, SINGLE_VALUE_TYPE("disable-download-upload")},
 
 #if !BUILDFLAG(IS_CHROMEOS_ASH)
     {"profiles-reordering", flag_descriptions::kProfilesReorderingName,


### PR DESCRIPTION
These flags dont work properly without this. I have made this exact same mistake when adding flags to https://github.com/Alex313031/thorium-win7/blob/main/src/chrome/browser/thorium_flag_entries.h LOL.

Discovered this when I was converting your M119 supermium patch into an unbranded Chromium patch.