### PR TITLE
BUILD.gn for SSE2 on x86

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -67,6 +67,17 @@ if (is_official_build) {
   assert(!is_component_build)
 }
 
+# Supermium target that simply pulls in the chrome target as a dependency
+group("supermium") {
+  if (is_win || is_linux || is_mac) {
+    deps = [ "//chrome:chrome" ]
+  }
+
+  if (is_win) {
+    deps += [ "//chrome:chrome_dll" ]
+  }
+}
+
 # The `gn_all` target is used to list all of the main targets in the build, so
 # that we can figure out which BUILD.gn files to process, following the process
 # described at the top of this file.

--- a/build/config/win/BUILD.gn
+++ b/build/config/win/BUILD.gn
@@ -133,6 +133,8 @@ config("compiler") {
     if (current_cpu == "x86" || current_cpu == "x64") {
         if (target_cpu == "x64") {
           cflags += [ "-msse3" ]
+        } else {
+          cflags += [ "-mmmx", "-mfxsr", "-msse", "-msse2", "/arch:SSE2" ]
         }
     }
 


### PR DESCRIPTION
 - Restore SSE2, as SSE3 was an artificial limitation introduced here >https://docs.google.com/document/d/1QUzL4MGNqX4wiLvukUwBf6FdCL35kCDoEJTm2wMkahw/edit#heading=h.7nki9mck5t64

 - -mx87 was *excluded* as it is not needed, and if you include it, some code paths that would otherwise be compiled with SIMD are instead compiled with the old, original (i.e. i386) x87 floating point math extensions.