### PR TITLE
NT 5.0 and spacing fix

### DIFF
--- a/build/config/win/BUILD.gn
+++ b/build/config/win/BUILD.gn
@@ -631,17 +631,9 @@ config("static_crt") {
 # Subsystem --------------------------------------------------------------------
 
 # This is appended to the subsystem to specify a minimum version.
-if (current_cpu == "x64") {
-  # The number after the comma is the minimum required OS version.
-  # 5.02 = Windows Server 2003.
-  subsystem_version_suffix = ",5.02"
-} else if (current_cpu == "arm64") {
-  # Windows ARM64 requires Windows 10.
-  subsystem_version_suffix = ",10.0"
-} else {
-  # 5.01 = Windows XP.
-  subsystem_version_suffix = ",5.01"
-}
+# The number after the comma is the minimum required OS version.
+# Set to NT 5.0 since this is for Windows 200/XP/Vista
+subsystem_version_suffix = ",5.00"
 
 config("console") {
   ldflags = [ "/SUBSYSTEM:CONSOLE$subsystem_version_suffix" ]

--- a/build/config/win/BUILD.gn
+++ b/build/config/win/BUILD.gn
@@ -632,7 +632,7 @@ config("static_crt") {
 
 # This is appended to the subsystem to specify a minimum version.
 # The number after the comma is the minimum required OS version.
-# Set to NT 5.0 since this is for Windows 200/XP/Vista
+# Set to NT 5.0 since this is for Windows 2000/XP/Vista
 subsystem_version_suffix = ",5.00"
 
 config("console") {

--- a/components/pdf/renderer/internal_plugin_renderer_helpers.cc
+++ b/components/pdf/renderer/internal_plugin_renderer_helpers.cc
@@ -30,7 +30,7 @@ namespace pdf {
 bool IsPdfRenderer() {
   static const bool has_switch =
       base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kPdfRenderer) ||
-      (base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kPdfRenderer) && base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kSingleProcess));
+      base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kSingleProcess);
   return has_switch;
 }
 

--- a/components/pdf/renderer/internal_plugin_renderer_helpers.cc
+++ b/components/pdf/renderer/internal_plugin_renderer_helpers.cc
@@ -30,7 +30,7 @@ namespace pdf {
 bool IsPdfRenderer() {
   static const bool has_switch =
       base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kPdfRenderer) ||
-	  base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kSingleProcess);
+	  base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kPdfRenderer) && base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kSingleProcess);
   return has_switch;
 }
 

--- a/components/pdf/renderer/internal_plugin_renderer_helpers.cc
+++ b/components/pdf/renderer/internal_plugin_renderer_helpers.cc
@@ -30,7 +30,7 @@ namespace pdf {
 bool IsPdfRenderer() {
   static const bool has_switch =
       base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kPdfRenderer) ||
-	  base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kPdfRenderer) && base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kSingleProcess);
+      (base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kPdfRenderer) && base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kSingleProcess));
   return has_switch;
 }
 


### PR DESCRIPTION
 - Set subsystem to NT 5.0, to allow testing on, and future support for Win 2000.

 - Your recent PDF patch is telling it that the process should always be treated as a PDFium Renderer, even when only the `--single-process` flag is added. This adds the && conditional.