### PR TITLE
Fix compact-ui omnibox outlines

### DIFF
--- a/chrome/browser/ui/views/location_bar/location_bar_view.cc
+++ b/chrome/browser/ui/views/location_bar/location_bar_view.cc
@@ -1181,13 +1181,12 @@ void LocationBarView::RefreshBackground() {
   // correctly enable subpixel AA.
   omnibox_view_->SetBackgroundColor(background_color);
   
-  if ((base::CommandLine::ForCurrentProcess()->HasSwitch("classic-omnibox") ||
-      base::CommandLine::ForCurrentProcess()->HasSwitch("classic-omnibox-border"))&&
-      base::CommandLine::ForCurrentProcess()->HasSwitch("compact-ui"))
-        // When the location bar is shrunken, the border above is only drawn on the sides.
-        // To resolve this, an extra border is drawn in that area on the top and bottom.
-        // Ideally, only one border would be drawn.
-	omnibox_view_->SetBorder(views::CreateSolidSidedBorder(gfx::Insets::TLBR(1, 0, 1, 0), SK_ColorGRAY));
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch("classic-omnibox-border") &&
+    base::CommandLine::ForCurrentProcess()->HasSwitch("compact-ui"))
+    // When the location bar is shrunken, the border above is only drawn on the sides.
+    // To resolve this, an extra border is drawn in that area on the top and bottom.
+    // Ideally, only one border would be drawn.
+    omnibox_view_->SetBorder(views::CreateSolidSidedBorder(gfx::Insets::TLBR(1, 0, 1, 0), SK_ColorGRAY));
 
   // The divider between indicators and request chips should have the same color
   // as the omnibox.


### PR DESCRIPTION
@win32ss If classic-omnibox and compact-ui are enabled (but not classic-omnibox-borders), since we separated them into two different flags, with the current code this is the result:

![Screenshot from 2024-06-05 21-59-42](https://github.com/win32ss/supermium/assets/45863095/d8889c7f-1242-4771-b630-4071e7bebbc0)

When applying this fix, the extra border is only drawn when classic-omnibox-borders and compact-ui are enabled, leading to the correct appearance like so (showing both with, and without the classic-omnibox flag):

![Screenshot from 2024-06-05 22-04-14](https://github.com/win32ss/supermium/assets/45863095/202ff537-1c53-4c33-a433-35a6a78ad18e)
![Screenshot from 2024-06-05 22-04-37](https://github.com/win32ss/supermium/assets/45863095/d0849e17-f9d8-442e-8d49-f012c7722ef5)

May have to zoom in lol.